### PR TITLE
Treeview expander color support

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3341,6 +3341,7 @@ murrine_draw_resize_grip (cairo_t *cr,
 static void
 murrine_draw_expander_arrow (cairo_t *cr,
 	                     const MurrineColors    *colors,
+	                     const MurrineRGB        custom_treeview_expander_color,
 	                     const WidgetParameters *widget,
 	                     const ExpanderParameters *expander,
 	                     int x, int y)
@@ -3427,11 +3428,15 @@ murrine_draw_expander_arrow (cairo_t *cr,
 	cairo_line_to (cr,  radius / 2.0 - offset,  0);
 	cairo_line_to (cr, -radius / 2.0 + offset,  radius / 2.0);
 	cairo_close_path (cr);
-	
+
 	if (expander->in_treeview)
-		color = colors->text[widget->state_type];
+	{
+                color = custom_treeview_expander_color;
+	}
 	else
+	{
 		color = colors->fg[widget->state_type];
+	}
 
 	pat = cairo_pattern_create_linear (-radius/2.0, 0, radius/2.0, 0);
 	murrine_pattern_add_color_stop_rgba (pat, 0.0, &color, 0.6);
@@ -3548,6 +3553,7 @@ murrine_draw_expander_button (cairo_t *cr,
 void 
 murrine_draw_expander (cairo_t *cr,
                        const MurrineColors    *colors,
+                       const MurrineRGB        treeview_expander_color,
                        const WidgetParameters *widget,
                        const ExpanderParameters *expander,
                        int x, int y)
@@ -3556,7 +3562,7 @@ murrine_draw_expander (cairo_t *cr,
 	{
 		default:
 		case 0:
-			murrine_draw_expander_arrow (cr, colors, widget, expander, x, y);
+			murrine_draw_expander_arrow (cr, colors, treeview_expander_color, widget, expander, x, y);
 			break;
 		case 1:
 			murrine_draw_expander_circle (cr, colors, widget, expander, x, y);

--- a/src/murrine_rc_style.c
+++ b/src/murrine_rc_style.c
@@ -76,6 +76,7 @@ enum
 	TOKEN_TEXTSTYLE,
 	TOKEN_TEXT_SHADE,
 	TOKEN_TOOLBARSTYLE,
+	TOKEN_TREEVIEW_EXPANDER_COLOR,
 	TOKEN_TROUGH_BORDER_SHADES,
 	TOKEN_TROUGH_SHADES,	
 
@@ -141,6 +142,7 @@ theme_symbols[] =
 	{ "textstyle",           TOKEN_TEXTSTYLE },
 	{ "text_shade",          TOKEN_TEXT_SHADE },
 	{ "toolbarstyle",        TOKEN_TOOLBARSTYLE },
+	{ "treeview_expander_color", TOKEN_TREEVIEW_EXPANDER_COLOR },
 	{ "trough_border_shades", TOKEN_TROUGH_BORDER_SHADES },
 	{ "trough_shades",       TOKEN_TROUGH_SHADES },
 
@@ -184,6 +186,7 @@ murrine_rc_style_init (MurrineRcStyle *murrine_rc)
 	murrine_rc->has_border_colors = FALSE;
 	murrine_rc->has_default_button_color = FALSE;
 	murrine_rc->has_gradient_colors = FALSE;
+	murrine_rc->has_treeview_expander_color = FALSE;
 	murrine_rc->handlestyle = 0;
 	murrine_rc->glazestyle = 1;
 	murrine_rc->glow_shade = 1.0;
@@ -785,6 +788,10 @@ murrine_rc_style_parse (GtkRcStyle *rc_style,
 				token = theme_parse_shade (settings, scanner, &murrine_style->text_shade);
 				murrine_style->flags |= MRN_FLAG_TEXT_SHADE;
 				break;
+			case TOKEN_TREEVIEW_EXPANDER_COLOR:
+				token = theme_parse_color (settings, scanner, rc_style, &murrine_style->treeview_expander_color);
+				murrine_style->flags |= MRN_FLAG_TREEVIEW_EXPANDER_COLOR;
+				break;
 			case TOKEN_TOOLBARSTYLE:
 				token = theme_parse_int (settings, scanner, &murrine_style->toolbarstyle);
 				murrine_style->flags |= MRN_FLAG_TOOLBARSTYLE;
@@ -884,6 +891,11 @@ murrine_rc_style_merge (GtkRcStyle *dest,
 	{
 		dest_w->has_default_button_color = src_w->has_default_button_color;
 		dest_w->default_button_color = src_w->default_button_color;
+	}
+	if (flags & MRN_FLAG_TREEVIEW_EXPANDER_COLOR)
+	{
+		dest_w->has_treeview_expander_color = src_w->has_treeview_expander_color;
+		dest_w->treeview_expander_color = src_w->treeview_expander_color;
 	}
 	if (flags & MRN_FLAG_EXPANDERSTYLE)
 		dest_w->expanderstyle = src_w->expanderstyle;

--- a/src/murrine_rc_style.h
+++ b/src/murrine_rc_style.h
@@ -67,7 +67,8 @@ typedef enum
 	MRN_FLAG_STEPPERSTYLE = 1 << 28,
 	MRN_FLAG_TEXTSTYLE = 1 << 29,
 	MRN_FLAG_TEXT_SHADE = 1 << 30,
-	MRN_FLAG_TOOLBARSTYLE = 1 << 31
+	MRN_FLAG_TOOLBARSTYLE = 1 << 31,
+	MRN_FLAG_TREEVIEW_EXPANDER_COLOR = 1 << 32
 } MurrineRcFlags;
 
 typedef enum
@@ -139,6 +140,7 @@ struct _MurrineRcStyle
 	gboolean animation;
 	gboolean colorize_scrollbar;
 	gboolean has_border_colors;
+	gboolean has_treeview_expander_color;
 	gboolean has_default_button_color;
 	gboolean has_focus_color;
 	gboolean has_gradient_colors;
@@ -148,6 +150,7 @@ struct _MurrineRcStyle
 	GdkColor default_button_color;
 	GdkColor focus_color;
 	GdkColor gradient_colors[4];
+	GdkColor treeview_expander_color;
 };
 
 struct _MurrineRcStyleClass

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2236,6 +2236,7 @@ murrine_style_draw_expander (GtkStyle        *style,
 {
 	MurrineStyle  *murrine_style = MURRINE_STYLE (style);
 	MurrineColors *colors = &murrine_style->colors;
+        MurrineRGB treeview_expander_color;
 
 	cairo_t *cr;
 
@@ -2258,7 +2259,19 @@ murrine_style_draw_expander (GtkStyle        *style,
 	expander.arrowstyle = murrine_style->arrowstyle;
 	expander.style = murrine_style->expanderstyle;
 
-	STYLE_FUNCTION(draw_expander) (cr, colors, &params, &expander, x, y);
+	if (murrine_style->has_treeview_expander_color)
+	{
+		murrine_gdk_color_to_rgb (&murrine_style->treeview_expander_color,
+					  &treeview_expander_color.r,
+					  &treeview_expander_color.g,
+					  &treeview_expander_color.b);
+	}
+	else
+	{
+		treeview_expander_color = colors->text[state_type];
+	}
+
+	STYLE_FUNCTION(draw_expander) (cr, colors, treeview_expander_color, &params, &expander, x, y);
 
 	cairo_destroy (cr);
 }
@@ -2504,6 +2517,7 @@ murrine_style_init_from_rc (GtkStyle   *style,
 	murrine_style->glowstyle           = MURRINE_RC_STYLE (rc_style)->glowstyle;
 	murrine_style->has_border_colors   = MURRINE_RC_STYLE (rc_style)->has_border_colors;
 	murrine_style->has_default_button_color = MURRINE_RC_STYLE (rc_style)->flags & MRN_FLAG_DEFAULT_BUTTON_COLOR;
+	murrine_style->has_treeview_expander_color = MURRINE_RC_STYLE (rc_style)->flags & MRN_FLAG_TREEVIEW_EXPANDER_COLOR;
 	murrine_style->has_focus_color     = MURRINE_RC_STYLE (rc_style)->flags & MRN_FLAG_FOCUS_COLOR;
 	murrine_style->has_gradient_colors = MURRINE_RC_STYLE (rc_style)->has_gradient_colors;
 	murrine_style->handlestyle         = MURRINE_RC_STYLE (rc_style)->handlestyle;
@@ -2534,6 +2548,8 @@ murrine_style_init_from_rc (GtkStyle   *style,
 	}
 	if (murrine_style->has_default_button_color)
 		murrine_style->default_button_color = MURRINE_RC_STYLE (rc_style)->default_button_color;
+	if (murrine_style->has_treeview_expander_color)
+		murrine_style->treeview_expander_color = MURRINE_RC_STYLE (rc_style)->treeview_expander_color;
 	if (murrine_style->has_focus_color)
 		murrine_style->focus_color = MURRINE_RC_STYLE (rc_style)->focus_color;
 	if (murrine_style->has_gradient_colors)
@@ -2657,6 +2673,7 @@ murrine_style_copy (GtkStyle *style, GtkStyle *src)
 	mrn_style->has_default_button_color = mrn_src->has_default_button_color;
 	mrn_style->has_focus_color     = mrn_src->has_focus_color;
 	mrn_style->has_gradient_colors = mrn_src->has_gradient_colors;
+	mrn_style->has_treeview_expander_color = mrn_src->has_treeview_expander_color;
 	mrn_style->highlight_shade     = mrn_src->highlight_shade;
 	mrn_style->lightborder_shade   = mrn_src->lightborder_shade;
 	mrn_style->lightborderstyle    = mrn_src->lightborderstyle;
@@ -2681,6 +2698,7 @@ murrine_style_copy (GtkStyle *style, GtkStyle *src)
 	mrn_style->textstyle           = mrn_src->textstyle;
 	mrn_style->text_shade          = mrn_src->text_shade;
 	mrn_style->toolbarstyle        = mrn_src->toolbarstyle;
+	mrn_style->treeview_expander_color = mrn_src->treeview_expander_color;
 	mrn_style->trough_border_shades[0] = mrn_src->trough_border_shades[0];
 	mrn_style->trough_border_shades[1] = mrn_src->trough_border_shades[1];
 	mrn_style->trough_shades[0]    = mrn_src->trough_shades[0];

--- a/src/murrine_style.h
+++ b/src/murrine_style.h
@@ -89,11 +89,13 @@ struct _MurrineStyle
 	gboolean has_focus_color;
 	gboolean has_gradient_colors;
 	gboolean rgba;
+	gboolean has_treeview_expander_color;
 
 	GdkColor border_colors[2];
 	GdkColor default_button_color;
 	GdkColor focus_color;
 	GdkColor gradient_colors[4];
+	GdkColor treeview_expander_color;
 };
 
 struct _MurrineStyleClass

--- a/src/murrine_types.h
+++ b/src/murrine_types.h
@@ -467,6 +467,7 @@ struct _MurrineStyleFunctions
 
 	void (*draw_expander) (cairo_t *cr,
 	                       const MurrineColors    *colors,
+	                       const MurrineRGB        treeview_expander_color,
 	                       const WidgetParameters *widget,
 	                       const ExpanderParameters *expander,
 	                       int x, int y);


### PR DESCRIPTION
The expander/disclosure triangle on treeviews is not very themable. Right now it uses the text color, which is `#000`.

This branch adds a new theme token `treeview_expander_color' to allow us to style the treeview expander/disclosure color.
