### PR TITLE
Fix button shadows

### DIFF
--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2114,7 +2114,6 @@ murrine_style_draw_layout (GtkStyle     *style,
 
 	if (widget && (state_type == GTK_STATE_INSENSITIVE || 
 	    (MURRINE_STYLE (style)->textstyle != 0 &&
-	     state_type != GTK_STATE_PRELIGHT &&
 	     !(DETAIL ("cellrenderertext") && state_type == GTK_STATE_NORMAL))))
 	{
 		MurrineStyle *murrine_style = MURRINE_STYLE (style);
@@ -2161,6 +2160,11 @@ murrine_style_draw_layout (GtkStyle     *style,
 		{
 			boolean use_parentbg = TRUE;
 
+			if (state_type == GTK_STATE_PRELIGHT) {
+				use_parentbg = FALSE;
+				goto draw;
+			}
+
 			while (widget->parent)
 			{
 				if (GTK_IS_SCROLLED_WINDOW (widget->parent))
@@ -2197,6 +2201,8 @@ murrine_style_draw_layout (GtkStyle     *style,
 
 				widget = widget->parent;
 			}
+
+			draw:
 
 			if (use_parentbg)
 				murrine_shade (&params.parentbg, shade_level, &temp);
@@ -2239,25 +2245,6 @@ murrine_style_draw_layout (GtkStyle     *style,
 		etched.blue = (int) (temp.b*65535);
 
 		gdk_draw_layout_with_colors(window, gc, x, y, layout, &etched, NULL);
-	}
-	else if (DETAIL ("label") && widget && gtk_widget_get_ancestor (widget, GTK_TYPE_BUTTON) && !gtk_widget_get_ancestor (widget, GTK_TYPE_TOGGLE_BUTTON))
-	{
-		if (is_yosemite ()) {
-			if (state_type == GTK_STATE_ACTIVE) {
-				GdkColor etched = { 0, 0, 0, 0 };
-		                GdkColor white = { 0, 65535, 65535, 65535 };
-				gdk_draw_layout_with_colors (window, gc, x, y + 1, layout, &etched, NULL);
-				gdk_draw_layout_with_colors (window, gc, x, y, layout, &white, NULL);
-			} else {
-				GdkColor etched = { 0, 65535, 65535, 65535 };
-				gdk_draw_layout_with_colors (window, gc, x, y + 1, layout, &etched, NULL);
-				gdk_draw_layout (window, gc, x, y, layout);
-			}
-		} else {
-			GdkColor etched = { 0, 65535, 65535, 65535 };
-			gdk_draw_layout_with_colors(window, gc, x, y + 1, layout, &etched, NULL);
-			gdk_draw_layout (window, gc, x, y, layout);
-		}
 	}
 	else
 		gdk_draw_layout (window, gc, x, y, layout);

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2244,7 +2244,13 @@ murrine_style_draw_layout (GtkStyle     *style,
 		gdk_draw_layout_with_colors(window, gc, x, y, layout, &etched, NULL);
 	}
 	else
-		gdk_draw_layout (window, gc, x, y, layout);
+	{
+		GtkWidget *button = gtk_widget_get_ancestor (widget, GTK_TYPE_BUTTON);
+		if (DETAIL ("label") && button)
+			gdk_draw_layout_with_colors(window, gc, x, y, layout, &button->style->fg[state_type], NULL);
+		else
+			gdk_draw_layout (window, gc, x, y, layout);
+	}
 
 	if (area)
 		gdk_gc_set_clip_rectangle (gc, NULL);

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2162,47 +2162,44 @@ murrine_style_draw_layout (GtkStyle     *style,
 
 			if (state_type == GTK_STATE_PRELIGHT) {
 				use_parentbg = FALSE;
-				goto draw;
-			}
-
-			while (widget->parent)
-			{
-				if (GTK_IS_SCROLLED_WINDOW (widget->parent))
-					goto out;
-
-				widget = widget->parent;
-			}
-
-			while (widget->parent)
-			{
-				if (MRN_IS_BUTTON (widget->parent) ||
-				    MRN_IS_TOGGLE_BUTTON (widget->parent) ||
-				    MRN_IS_COMBO_BOX (widget->parent) ||
-				    MRN_IS_COMBO_BOX_ENTRY (widget->parent) ||
-				    MRN_IS_COMBO (widget->parent) ||
-				    MRN_IS_OPTION_MENU (widget->parent) ||
-				    MRN_IS_NOTEBOOK (widget->parent))
+			} else {
+				while (widget->parent)
 				{
-					GtkReliefStyle relief = GTK_RELIEF_NORMAL;
+					if (GTK_IS_SCROLLED_WINDOW (widget->parent))
+						goto out;
 
-					/* Check for the shadow type. */
-					if (MRN_IS_BUTTON (widget->parent))
-						g_object_get (G_OBJECT (widget->parent), "relief", &relief, NULL);
-
-					if (!MRN_IS_CHECK_BUTTON(widget->parent) &&
-					    !MRN_IS_RADIO_BUTTON(widget->parent) &&
-					    !(relief == GTK_RELIEF_NONE &&
-					      (state_type == GTK_STATE_NORMAL ||
-					       state_type == GTK_STATE_INSENSITIVE)))
-						use_parentbg = FALSE;
-
-					break;
+					widget = widget->parent;
 				}
 
-				widget = widget->parent;
-			}
+				while (widget->parent)
+				{
+					if (MRN_IS_BUTTON (widget->parent) ||
+					    MRN_IS_TOGGLE_BUTTON (widget->parent) ||
+					    MRN_IS_COMBO_BOX (widget->parent) ||
+					    MRN_IS_COMBO_BOX_ENTRY (widget->parent) ||
+					    MRN_IS_COMBO (widget->parent) ||
+					    MRN_IS_OPTION_MENU (widget->parent) ||
+					    MRN_IS_NOTEBOOK (widget->parent))
+					{
+						GtkReliefStyle relief = GTK_RELIEF_NORMAL;
 
-			draw:
+						/* Check for the shadow type. */
+						if (MRN_IS_BUTTON (widget->parent))
+							g_object_get (G_OBJECT (widget->parent), "relief", &relief, NULL);
+
+						if (!MRN_IS_CHECK_BUTTON(widget->parent) &&
+						    !MRN_IS_RADIO_BUTTON(widget->parent) &&
+						    !(relief == GTK_RELIEF_NONE &&
+						      (state_type == GTK_STATE_NORMAL ||
+						       state_type == GTK_STATE_INSENSITIVE)))
+							use_parentbg = FALSE;
+
+						break;
+					}
+
+					widget = widget->parent;
+				}
+			}
 
 			if (use_parentbg)
 				murrine_shade (&params.parentbg, shade_level, &temp);


### PR DESCRIPTION
Buttons should not have any static text shadows by default, because it does not work for dark Gtk themes. This patch disables the white (hardcoded) text shadow and adds `textstyle` support for the prelight state on buttons. To configure text shadows the `textstyle` and `text_shade`
settings should be used.

Original shadows (`textstyle==0`):
![image](https://cloud.githubusercontent.com/assets/951587/11041773/e75a141e-8713-11e5-91d8-19a54d7f4289.png)
![image](https://cloud.githubusercontent.com/assets/951587/11041764/dd1e871e-8713-11e5-9768-dd3941f2cd38.png)

Fixed shadows (`textstyle==0`):
![image](https://cloud.githubusercontent.com/assets/951587/11041684/83736036-8713-11e5-9b5d-40fab51bf3fa.png)
![image](https://cloud.githubusercontent.com/assets/951587/11041712/ad8e812a-8713-11e5-80e8-525c34dce8e5.png)