### PR TITLE
Draw ScrollBar background using child background color

### DIFF
--- a/src/murrine_rc_style.c
+++ b/src/murrine_rc_style.c
@@ -78,7 +78,8 @@ enum
 	TOKEN_TOOLBARSTYLE,
 	TOKEN_TREEVIEW_EXPANDER_COLOR,
 	TOKEN_TROUGH_BORDER_SHADES,
-	TOKEN_TROUGH_SHADES,	
+	TOKEN_TROUGH_SHADES,
+	TOKEN_TROUGH_USE_CHILD_BG,
 
 	TOKEN_TRUE,
 	TOKEN_FALSE,
@@ -145,6 +146,7 @@ theme_symbols[] =
 	{ "treeview_expander_color", TOKEN_TREEVIEW_EXPANDER_COLOR },
 	{ "trough_border_shades", TOKEN_TROUGH_BORDER_SHADES },
 	{ "trough_shades",       TOKEN_TROUGH_SHADES },
+	{ "trough_use_child_bg", TOKEN_TROUGH_USE_CHILD_BG },
 
 	{ "TRUE",                TOKEN_TRUE },
 	{ "FALSE",               TOKEN_FALSE },
@@ -223,6 +225,7 @@ murrine_rc_style_init (MurrineRcStyle *murrine_rc)
 	murrine_rc->trough_border_shades[1] = 1.0;
 	murrine_rc->trough_shades[0] = 1.0;
 	murrine_rc->trough_shades[1] = 1.0;
+	murrine_rc->trough_use_child_bg = TRUE;
 }
 
 #ifdef HAVE_ANIMATION
@@ -804,6 +807,10 @@ murrine_rc_style_parse (GtkRcStyle *rc_style,
 				token = theme_parse_border (settings, scanner, murrine_style->trough_shades);
 				murrine_style->gflags |= MRN_FLAG_TROUGH_SHADES;
 				break;
+			case TOKEN_TROUGH_USE_CHILD_BG:
+				token = theme_parse_boolean (settings, scanner, &murrine_style->trough_use_child_bg);
+				murrine_style->bflags |= MRN_FLAG_TROUGH_USE_CHILD_BG;
+				break;
 
 			/* stuff to ignore */
 			case TOKEN_GRADIENTS:
@@ -970,6 +977,9 @@ murrine_rc_style_merge (GtkRcStyle *dest,
 		dest_w->rgba = src_w->rgba;
 	if (bflags & MRN_FLAG_ROUNDNESS)
 		dest_w->roundness = src_w->roundness;
+	if (bflags & MRN_FLAG_TROUGH_USE_CHILD_BG)
+		dest_w->trough_use_child_bg = src_w->trough_use_child_bg;
+
 
 	dest_w->bflags |= src_w->bflags;
 

--- a/src/murrine_rc_style.h
+++ b/src/murrine_rc_style.h
@@ -77,7 +77,8 @@ typedef enum
 	MRN_FLAG_COLORIZE_SCROLLBAR = 1 << 1,
 	MRN_FLAG_CONTRAST = 1 << 2,
 	MRN_FLAG_RGBA = 1 << 3,
-	MRN_FLAG_ROUNDNESS = 1 << 4
+	MRN_FLAG_ROUNDNESS = 1 << 4,
+	MRN_FLAG_TROUGH_USE_CHILD_BG = 1 << 5
 } MurrineRcBasicFlags;
 
 typedef enum
@@ -89,7 +90,7 @@ typedef enum
 	MRN_FLAG_GRADIENT_SHADES = 1 << 4,
 	MRN_FLAG_SHADOW_SHADES = 1 << 5,
 	MRN_FLAG_TROUGH_BORDER_SHADES = 1 << 6,
-	MRN_FLAG_TROUGH_SHADES = 1 << 7
+	MRN_FLAG_TROUGH_SHADES = 1 << 7,
 } MurrineRcGradientFlags;
 
 struct _MurrineRcStyle
@@ -146,6 +147,7 @@ struct _MurrineRcStyle
 	gboolean has_focus_color;
 	gboolean has_gradient_colors;
 	gboolean rgba;
+	gboolean trough_use_child_bg;
 
 	GdkColor border_colors[2];
 	GdkColor default_button_color;

--- a/src/murrine_style.h
+++ b/src/murrine_style.h
@@ -90,6 +90,7 @@ struct _MurrineStyle
 	gboolean has_gradient_colors;
 	gboolean rgba;
 	gboolean has_treeview_expander_color;
+	gboolean trough_use_child_bg;
 
 	GdkColor border_colors[2];
 	GdkColor default_button_color;


### PR DESCRIPTION
The scrollbar trough is drawn using the background color of the content inside a scrolled window. The new behavior can be overridden using `trough_use_child_bg` option, which is enabled by default.

The patch includes a special TreeView handling: use `even-row-color` or the base color instead of the (default) bg color.