### PR TITLE
Add fill_shade option

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -555,7 +555,10 @@ murrine_draw_spinbutton (cairo_t *cr,
 {
 	ButtonParameters button;
 	button.has_default_button_color = FALSE;
-	button.fill_shade = 0.855;
+	if (widget->has_fill_shade)
+		button.fill_shade = widget->fill_shade;
+	else
+		button.fill_shade = 0.855;
 	button.border_shade = 0.6;
 	button.draw_glaze = FALSE;
 
@@ -1135,7 +1138,10 @@ murrine_draw_combobox (cairo_t *cr,
 		{
 			ButtonParameters button;
 			button.has_default_button_color = FALSE;
-			button.fill_shade = 0.899;
+			if (widget.has_fill_shade)
+				button.fill_shade = widget.fill_shade;
+			else
+				button.fill_shade = 0.899;
 			button.border_shade = 0.529;
 			button.draw_glaze = FALSE;
 
@@ -1154,7 +1160,10 @@ murrine_draw_combobox (cairo_t *cr,
 				box_w--;
 
 			button.has_default_button_color = FALSE;
-			button.fill_shade = 0.899;
+			if (widget.has_fill_shade)
+				button.fill_shade = widget.fill_shade;
+			else
+				button.fill_shade = 0.899;
 			button.border_shade = 0.6;
 			button.draw_glaze = FALSE;
 
@@ -1188,7 +1197,10 @@ murrine_draw_combobox (cairo_t *cr,
 
 			params.mrn_gradient.has_border_colors = FALSE;
 			params.mrn_gradient.has_gradient_colors = FALSE;
-			button.fill_shade = 0.866;
+			if (widget.has_fill_shade)
+				button.fill_shade = widget.fill_shade;
+			else
+				button.fill_shade = 0.866;
 
 			cairo_save (cr);
 			if (params.ltr)
@@ -1224,7 +1236,10 @@ murrine_draw_optionmenu (cairo_t *cr,
 	boolean horizontal = TRUE;
 
 	button.has_default_button_color = FALSE;
-	button.fill_shade = 0.855;
+	if (widget->has_fill_shade)
+		button.fill_shade = widget->fill_shade;
+	else
+		button.fill_shade = 0.855;
 	button.border_shade = 0.6;
 	button.draw_glaze = FALSE;
 

--- a/src/murrine_rc_style.c
+++ b/src/murrine_rc_style.c
@@ -45,6 +45,7 @@ enum
 	TOKEN_CONTRAST,
 	TOKEN_DEFAULT_BUTTON_COLOR,
 	TOKEN_EXPANDERSTYLE,
+	TOKEN_FILL_SHADE,
 	TOKEN_FOCUS_COLOR,
 	TOKEN_FOCUSSTYLE,
 	TOKEN_GLAZESTYLE,
@@ -111,6 +112,7 @@ theme_symbols[] =
 	{ "contrast",            TOKEN_CONTRAST },
 	{ "default_button_color", TOKEN_DEFAULT_BUTTON_COLOR },
 	{ "expanderstyle",       TOKEN_EXPANDERSTYLE },
+	{ "fill_shade",          TOKEN_FILL_SHADE },
 	{ "focus_color",         TOKEN_FOCUS_COLOR },
 	{ "focusstyle",          TOKEN_FOCUSSTYLE },
 	{ "glazestyle",          TOKEN_GLAZESTYLE },
@@ -185,6 +187,7 @@ murrine_rc_style_init (MurrineRcStyle *murrine_rc)
 	murrine_rc->focusstyle = 2;
 	murrine_rc->has_border_colors = FALSE;
 	murrine_rc->has_default_button_color = FALSE;
+	murrine_rc->has_fill_shade = FALSE;
 	murrine_rc->has_gradient_colors = FALSE;
 	murrine_rc->has_treeview_expander_color = FALSE;
 	murrine_rc->handlestyle = 0;
@@ -668,6 +671,10 @@ murrine_rc_style_parse (GtkRcStyle *rc_style,
 				token = theme_parse_int (settings, scanner, &murrine_style->expanderstyle);
 				murrine_style->flags |= MRN_FLAG_EXPANDERSTYLE;
 				break;
+			case TOKEN_FILL_SHADE:
+				token = theme_parse_shade (settings, scanner, &murrine_style->fill_shade);
+				murrine_style->has_fill_shade = TRUE;
+				break;
 			case TOKEN_FOCUS_COLOR:
 				token = theme_parse_color (settings, scanner, rc_style, &murrine_style->focus_color);
 				murrine_style->flags |= MRN_FLAG_FOCUS_COLOR;
@@ -899,6 +906,11 @@ murrine_rc_style_merge (GtkRcStyle *dest,
 	}
 	if (flags & MRN_FLAG_EXPANDERSTYLE)
 		dest_w->expanderstyle = src_w->expanderstyle;
+	if (src_w->has_fill_shade)
+	{
+		dest_w->has_fill_shade = src_w->has_fill_shade;
+		dest_w->fill_shade = src_w->fill_shade;
+	}
 	if (flags & MRN_FLAG_FOCUS_COLOR)
 	{
 		dest_w->has_focus_color = src_w->has_focus_color;

--- a/src/murrine_rc_style.h
+++ b/src/murrine_rc_style.h
@@ -102,6 +102,7 @@ struct _MurrineRcStyle
 
 	double   border_shades[2];
 	double   contrast;
+	double   fill_shade;
 	double   glow_shade;
 	double   gradient_shades[4];
 	double   highlight_shade;
@@ -143,6 +144,7 @@ struct _MurrineRcStyle
 	gboolean has_border_colors;
 	gboolean has_treeview_expander_color;
 	gboolean has_default_button_color;
+	gboolean has_fill_shade;
 	gboolean has_focus_color;
 	gboolean has_gradient_colors;
 	gboolean rgba;

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -169,6 +169,8 @@ murrine_set_widget_parameters (const GtkWidget  *widget,
 	params->ythickness = style->ythickness;
 
 	params->contrast          = murrine_style->contrast;
+	params->fill_shade        = murrine_style->fill_shade;
+	params->has_fill_shade    = murrine_style->has_fill_shade;
 	params->glazestyle        = murrine_style->glazestyle;
 	params->glow_shade        = murrine_style->glow_shade;
 	params->glowstyle         = murrine_style->glowstyle;
@@ -924,7 +926,10 @@ murrine_style_draw_box (DRAW_ARGS)
 
 		murrine_set_widget_parameters (widget, style, state_type, &params);
 		params.active = shadow_type == GTK_SHADOW_IN;
-		button.fill_shade = 0.855;
+		if (murrine_style->has_fill_shade)
+			button.fill_shade = murrine_style->fill_shade;
+		else
+			button.fill_shade = 0.855;
 		button.border_shade = 0.6;
 		button.draw_glaze = TRUE;
 
@@ -993,7 +998,8 @@ murrine_style_draw_box (DRAW_ARGS)
 			 MRN_IS_COMBO (widget->parent))
 		{
 			if (GTK_IS_TOGGLE_BUTTON (widget))
-				button.fill_shade = 0.934;
+				if (!murrine_style->has_fill_shade)
+					button.fill_shade = 0.934;
 			STYLE_FUNCTION(draw_button) (cr, &murrine_style->colors, &params, &button, x, y+4, width, height-8, horizontal);
 		}
 		else
@@ -1382,7 +1388,10 @@ murrine_style_draw_box (DRAW_ARGS)
 		murrine_set_widget_parameters (widget, style, state_type, &params);
 
 		button.has_default_button_color = FALSE;
-		button.fill_shade = 0.855;
+		if (murrine_style->has_fill_shade)
+			button.fill_shade = murrine_style->fill_shade;
+		else
+			button.fill_shade = 0.855;
 		button.border_shade = 0.6;
 		button.draw_glaze = FALSE;
 
@@ -1463,7 +1472,10 @@ murrine_style_draw_box (DRAW_ARGS)
 		{
 			ButtonParameters button;
 			button.has_default_button_color = FALSE;
-			button.fill_shade = 0.855;
+			if (murrine_style->has_fill_shade)
+				button.fill_shade = murrine_style->fill_shade;
+			else
+				button.fill_shade = 0.855;
 			button.border_shade = 0.6;
 			button.draw_glaze = FALSE;
 
@@ -2561,6 +2573,7 @@ murrine_style_init_from_rc (GtkStyle   *style,
 	murrine_style->has_border_colors   = MURRINE_RC_STYLE (rc_style)->has_border_colors;
 	murrine_style->has_default_button_color = MURRINE_RC_STYLE (rc_style)->flags & MRN_FLAG_DEFAULT_BUTTON_COLOR;
 	murrine_style->has_treeview_expander_color = MURRINE_RC_STYLE (rc_style)->has_treeview_expander_color;
+	murrine_style->has_fill_shade      = MURRINE_RC_STYLE (rc_style)->has_fill_shade;
 	murrine_style->has_focus_color     = MURRINE_RC_STYLE (rc_style)->flags & MRN_FLAG_FOCUS_COLOR;
 	murrine_style->has_gradient_colors = MURRINE_RC_STYLE (rc_style)->has_gradient_colors;
 	murrine_style->handlestyle         = MURRINE_RC_STYLE (rc_style)->handlestyle;
@@ -2593,6 +2606,8 @@ murrine_style_init_from_rc (GtkStyle   *style,
 		murrine_style->default_button_color = MURRINE_RC_STYLE (rc_style)->default_button_color;
 	if (murrine_style->has_treeview_expander_color)
 		murrine_style->treeview_expander_color = MURRINE_RC_STYLE (rc_style)->treeview_expander_color;
+	if (murrine_style->has_fill_shade)
+		murrine_style->fill_shade = MURRINE_RC_STYLE (rc_style)->fill_shade;
 	if (murrine_style->has_focus_color)
 		murrine_style->focus_color = MURRINE_RC_STYLE (rc_style)->focus_color;
 	if (murrine_style->has_gradient_colors)
@@ -2698,6 +2713,7 @@ murrine_style_copy (GtkStyle *style, GtkStyle *src)
 	mrn_style->contrast            = mrn_src->contrast;
 	mrn_style->default_button_color = mrn_src->default_button_color;
 	mrn_style->expanderstyle       = mrn_src->expanderstyle;
+	mrn_style->fill_shade          = mrn_src->fill_shade;
 	mrn_style->focusstyle          = mrn_src->focusstyle;
 	mrn_style->focus_color         = mrn_src->focus_color;
 	mrn_style->glazestyle          = mrn_src->glazestyle;
@@ -2714,6 +2730,7 @@ murrine_style_copy (GtkStyle *style, GtkStyle *src)
 	mrn_style->handlestyle         = mrn_src->handlestyle;
 	mrn_style->has_border_colors   = mrn_src->has_border_colors;
 	mrn_style->has_default_button_color = mrn_src->has_default_button_color;
+	mrn_style->has_fill_shade      = mrn_src->has_fill_shade;
 	mrn_style->has_focus_color     = mrn_src->has_focus_color;
 	mrn_style->has_gradient_colors = mrn_src->has_gradient_colors;
 	mrn_style->has_treeview_expander_color = mrn_src->has_treeview_expander_color;

--- a/src/murrine_style.h
+++ b/src/murrine_style.h
@@ -46,6 +46,7 @@ struct _MurrineStyle
 
 	double   border_shades[2];
 	double   contrast;
+	double   fill_shade;
 	double   glow_shade;
 	double   gradient_shades[4];
 	double   highlight_shade;
@@ -86,6 +87,7 @@ struct _MurrineStyle
 	gboolean colorize_scrollbar;
 	gboolean has_border_colors;
 	gboolean has_default_button_color;
+	gboolean has_fill_shade;
 	gboolean has_focus_color;
 	gboolean has_gradient_colors;
 	gboolean rgba;

--- a/src/murrine_types.h
+++ b/src/murrine_types.h
@@ -386,6 +386,8 @@ typedef struct
 	int reliefstyle;
 	int roundness;
 	double contrast;
+	double fill_shade;
+	boolean has_fill_shade;
 	double glow_shade;
 	double highlight_shade;
 	double lightborder_shade;


### PR DESCRIPTION
Makes the fill gradient factor (used to draw various button backgrounds) configurable. The original internal defaults are used, if the option is not specified.