### PR TITLE
Add rudimentary draw-border style property support

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -306,7 +306,7 @@ murrine_draw_button (cairo_t *cr,
 		cairo_restore (cr);
 	}
 
-	murrine_draw_border (cr, &border,
+	murrine_draw_border (cr, widget->draw_border ? &border : &colors->bg[widget->state_type],
 	                     os+0.5, os+0.5, width-(os*2)-1, height-(os*2)-1,
 	                     widget->roundness, widget->corners,
 	                     mrn_gradient_new, 1.0);
@@ -1116,7 +1116,7 @@ murrine_draw_progressbar_fill (cairo_t *cr,
 	cairo_clip (cr);
 
 	/* Draw border */
-	murrine_draw_border (cr, &colors->fg[GTK_STATE_SELECTED],
+	murrine_draw_border (cr, widget->draw_border ? &colors->fg[GTK_STATE_SELECTED] : &colors->bg[GTK_STATE_SELECTED],
 	                     1.5, 0.5+yos, width-3, height-1,
 	                     roundness, widget->corners,
 	                     widget->mrn_gradient, 1.0);
@@ -2222,7 +2222,7 @@ murrine_draw_scrollbar_stepper (cairo_t *cr,
 
 	cairo_restore (cr);
 
-	murrine_draw_border (cr, &border,
+	murrine_draw_border (cr, widget->draw_border ? &border : &colors->bg[widget->state_type],
 	                     0.5, 0.5, width-1, height-1,
 	                     widget->roundness, widget->corners,
 	                     mrn_gradient_new, 1.0);
@@ -2461,7 +2461,7 @@ murrine_draw_scrollbar_slider (cairo_t *cr,
 
 	cairo_restore (cr);
 
-	murrine_draw_border (cr, &border,
+	murrine_draw_border (cr, widget->draw_border ? &border : &colors->bg[widget->state_type],
 	                     0.5, 0.5, width-1, height-1,
 			     MIN (width, height), corners,
 	                     mrn_gradient_new, 1.0);

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -164,6 +164,13 @@ murrine_set_widget_parameters (const GtkWidget  *widget,
 	params->ltr        = murrine_widget_is_ltr ((GtkWidget*)widget);
 	params->focus      = (MURRINE_STYLE (style)->focusstyle != 0) && widget && GTK_WIDGET_HAS_FOCUS (widget);
 	params->is_default = widget && GTK_WIDGET_HAS_DEFAULT (widget);
+	
+	GtkBorder *draw_border = NULL;
+	gtk_widget_style_get ((GtkWidget*)widget, "draw-border", &draw_border, NULL);
+	// draw whole border with 1px if at least one side is >0
+	// TODO: handle the specified border thicknesses,
+	//       needs complete border drawing rewrite
+	params->draw_border = (!draw_border) || (draw_border->left > 0 || draw_border->top > 0 || draw_border->right > 0 || draw_border->bottom > 0);
 
 	params->xthickness = style->xthickness;
 	params->ythickness = style->ythickness;

--- a/src/murrine_types.h
+++ b/src/murrine_types.h
@@ -373,6 +373,7 @@ typedef struct
 	boolean ltr;
 	boolean focus;
 	boolean is_default;
+	boolean draw_border;
 	MurrineStateType state_type;
 	uint8 corners;
 	uint8 xthickness;


### PR DESCRIPTION
A border is rendered only if at least one side of the border
(specified by the draw-border style property) is `>0`.

Limitation: murrine draws always a 1px border on all sides.
This patch allows it to enable/disable borders, but does not
add support for borders with different sizes.

Implemented widgets: GtkButton, GtkScrollbar, GtkProgressBar