### PR TITLE
Fix warning for missing draw-child-bg style property

### DIFF
--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -1180,7 +1180,8 @@ murrine_style_draw_box (DRAW_ARGS)
 		if (widget->parent && MRN_IS_SCROLLED_WINDOW (widget->parent))
 		{
 			gtk_widget_style_get (widget->parent, "scrollbars-within-bevel", &within_bevel, NULL);
-			gtk_widget_style_get (widget->parent, "draw-child-bg", &draw_child_bg, NULL);
+			if (gtk_widget_class_find_style_property (GTK_WIDGET_GET_CLASS (widget->parent), "draw-child-bg")) // no warnings with unpatched Gtk
+				gtk_widget_style_get (widget->parent, "draw-child-bg", &draw_child_bg, NULL);
 		}
 
 		scrollbar.horizontal   = TRUE;


### PR DESCRIPTION
If the `draw-child-bg` GtkScrollbar style property is not registered Gtk (unpatched) spits a warning every time the scrollbar is redrawn. This patch adds a check for existance of that property and retrieves its value only if Gtk is patched.