### PR TITLE
Disable checkbox background in prelight state

### DIFF
--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -398,6 +398,10 @@ murrine_style_draw_flat_box (DRAW_ARGS)
 				cairo_destroy (cr);
 			}
 		}
+		else if ((DETAIL("checkbutton") || DETAIL("radiobutton")) && state_type == GTK_STATE_PRELIGHT)
+		{
+			// don't draw prelight background for checkbutton / optionbutton
+		}
 		else
 		{
 /*			printf( "draw_flat_box: %s %s\n", detail, G_OBJECT_TYPE_NAME (widget));*/


### PR DESCRIPTION
The background of a check/option button (not box, but whole button area) should not change in prelight state.