### PR TITLE
Fix fill_shade property cloning

### DIFF
--- a/src/murrine_rc_style.c
+++ b/src/murrine_rc_style.c
@@ -906,7 +906,7 @@ murrine_rc_style_merge (GtkRcStyle *dest,
 	}
 	if (flags & MRN_FLAG_EXPANDERSTYLE)
 		dest_w->expanderstyle = src_w->expanderstyle;
-	if (src_w->has_fill_shade)
+	if (!dest_w->has_fill_shade)
 	{
 		dest_w->has_fill_shade = src_w->has_fill_shade;
 		dest_w->fill_shade = src_w->fill_shade;


### PR DESCRIPTION
Copy fill_shade from parent style only if it has not been set in the child style.