### PR TITLE
New CheckButton/RadioButton design

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3217,7 +3217,6 @@ murrine_draw_checkbox (cairo_t *cr,
 	gboolean inconsistent = FALSE;
 	gboolean draw_box = !checkbox->in_menu;
 	gboolean draw_bullet = (checkbox->shadow_type == GTK_SHADOW_IN);
-	int roundness = CLAMP (widget->roundness, 0, 2);
 	MurrineGradients mrn_gradient_new = widget->mrn_gradient;
 
 	inconsistent = (checkbox->shadow_type == GTK_SHADOW_ETCHED_IN);
@@ -3241,7 +3240,7 @@ murrine_draw_checkbox (cairo_t *cr,
 				if (widget->reliefstyle == 5)
 					murrine_draw_shadow (cr, &widget->parentbg,
 					                     0.5, 0.5, width-1, height-1,
-					                     roundness+1, widget->corners,
+					                     widget->roundness+1, widget->corners,
 					                     widget->reliefstyle,
 					                     mrn_gradient_new, 0.5);
 				else
@@ -3251,18 +3250,18 @@ murrine_draw_checkbox (cairo_t *cr,
 
 					murrine_draw_shadow (cr, &shadow,
 					                     0.5, 0.5, width-1, height-1,
-					                     roundness+1, widget->corners,
+					                     widget->roundness+1, widget->corners,
 					                     widget->reliefstyle,
 					                     mrn_gradient_new, 0.08);
 				}
 			}
 			else if (widget->reliefstyle != 0)
-				murrine_draw_inset (cr, &widget->parentbg, 0.5, 0.5, width-1, height-1, roundness+1, widget->corners);
+				murrine_draw_inset (cr, &widget->parentbg, 0.5, 0.5, width-1, height-1, widget->roundness+1, widget->corners);
 		}
 
 		cairo_save (cr);
 
-		murrine_rounded_rectangle_closed (cr, 1.5, 1.5, width-3, height-3, roundness, widget->corners);
+		murrine_rounded_rectangle_closed (cr, 1.5, 1.5, width-3, height-3, widget->roundness, widget->corners);
 		cairo_clip_preserve (cr);
 
 		double fill_shade = 0.85;
@@ -3288,7 +3287,7 @@ murrine_draw_checkbox (cairo_t *cr,
 
 		murrine_draw_border (cr, &border,
 		                     1.5, 1.5, width-3, height-3,
-		                     roundness, widget->corners,
+		                     widget->roundness, widget->corners,
 		                     mrn_gradient_new, 1.0);
 	}
 

--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3172,11 +3172,6 @@ murrine_draw_radiobutton (cairo_t *cr,
 			if (!draw_bullet)
 				mrn_gradient_new.has_border_colors = FALSE;
 		}
-		else if (!draw_bullet)
-		{
-			mrn_gradient_new = murrine_get_inverted_border_shades (mrn_gradient_new);
-			mrn_gradient_new.has_border_colors = FALSE;
-		}
 
 		murrine_draw_border (cr, &border,
 			             1.5, 1.5, width-3, height-3,
@@ -3323,11 +3318,6 @@ murrine_draw_checkbox (cairo_t *cr,
 			mrn_gradient_new.border_shades[1] = 1.0;
 			if (!draw_bullet)
 				mrn_gradient_new.has_border_colors = FALSE;
-		}
-		else if (!draw_bullet)
-		{
-			mrn_gradient_new = murrine_get_inverted_border_shades (mrn_gradient_new);
-			mrn_gradient_new.has_border_colors = FALSE;
 		}
 
 		murrine_draw_border (cr, &border,

--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3096,7 +3096,7 @@ murrine_draw_radiobutton (cairo_t *cr,
 	
 	// a optionbox has no active state, so we use this color for the checked state
 	if (!checkbox->in_cell && draw_bullet && widget->state_type == GTK_STATE_NORMAL)
-		bg = colors->base[GTK_STATE_SELECTED];
+		bg = colors->base[GTK_STATE_ACTIVE];
 
 	border = colors->text[widget->state_type];
 	dot = colors->text[widget->state_type];
@@ -3224,7 +3224,7 @@ murrine_draw_checkbox (cairo_t *cr,
 	
 	// a checkbox has no active state, so we use this color for the checked state
 	if (!checkbox->in_cell && draw_bullet && widget->state_type == GTK_STATE_NORMAL)
-		bg = colors->base[GTK_STATE_SELECTED];
+		bg = colors->base[GTK_STATE_ACTIVE];
 
 	cairo_translate (cr, x, y);
 

--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3081,14 +3081,13 @@ murrine_draw_radiobutton (cairo_t *cr,
                           int x, int y, int width, int height,
                           double trans)
 {
-	MurrineRGB dot, upper_fill, border;
+	MurrineRGB border = colors->text[widget->state_type];
+	MurrineRGB dot = colors->text[widget->state_type];
 	MurrineRGB bg = colors->base[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
 	gboolean inconsistent = FALSE;
 	gboolean draw_box = !checkbox->in_menu;
 	gboolean draw_bullet = (checkbox->shadow_type == GTK_SHADOW_IN);
 	int roundness = width+height;
-	double highlight_shade_new = widget->highlight_shade;
-	double lightborder_shade_new = widget->lightborder_shade;
 	MurrineGradients mrn_gradient_new = widget->mrn_gradient;
 	cairo_pattern_t *pat;
 
@@ -3099,28 +3098,14 @@ murrine_draw_radiobutton (cairo_t *cr,
 	if (!checkbox->in_cell && draw_bullet && widget->state_type == GTK_STATE_NORMAL)
 		bg = colors->base[GTK_STATE_SELECTED];
 
-	if (widget->state_type == GTK_STATE_INSENSITIVE)
-	{
-		border = colors->shade[3];
-		dot    = colors->shade[3];
-		bg     = colors->bg[0];
-
-		mrn_gradient_new = murrine_get_decreased_gradient_shades (widget->mrn_gradient, 3.0);
-		mrn_gradient_new.border_shades[0] = murrine_get_decreased_shade (widget->mrn_gradient.border_shades[0], 3.0);
-		mrn_gradient_new.border_shades[1] = murrine_get_decreased_shade (widget->mrn_gradient.border_shades[1], 3.0);
-		highlight_shade_new = murrine_get_decreased_shade (widget->highlight_shade, 2.0);
-		lightborder_shade_new = murrine_get_decreased_shade (widget->lightborder_shade, 2.0);
-	}
-	else
-	{
-		border = colors->text[widget->state_type];
-		dot = colors->text[widget->state_type];
-	}
+	border = colors->text[widget->state_type];
+	dot = colors->text[widget->state_type];
 
 	cairo_translate (cr, x, y);
 
 	if (draw_box)
 	{	
+		MurrineRGB upper_fill;
 		if (widget->xthickness > 2 && widget->ythickness > 2)
 		{
 			if (widget->reliefstyle > 1 && draw_bullet && widget->state_type != GTK_STATE_INSENSITIVE)
@@ -3226,15 +3211,13 @@ murrine_draw_checkbox (cairo_t *cr,
                        int x, int y, int width, int height,
                        double trans)
 {
-	MurrineRGB border;
-	const MurrineRGB *dot;
+	MurrineRGB border = colors->text[widget->state_type];
+	MurrineRGB dot = colors->text[widget->state_type];
 	MurrineRGB bg = colors->base[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
 	gboolean inconsistent = FALSE;
 	gboolean draw_box = !checkbox->in_menu;
 	gboolean draw_bullet = (checkbox->shadow_type == GTK_SHADOW_IN);
 	int roundness = CLAMP (widget->roundness, 0, 2);
-	double highlight_shade_new = widget->highlight_shade;
-	double lightborder_shade_new = widget->lightborder_shade;
 	MurrineGradients mrn_gradient_new = widget->mrn_gradient;
 
 	inconsistent = (checkbox->shadow_type == GTK_SHADOW_ETCHED_IN);
@@ -3243,23 +3226,6 @@ murrine_draw_checkbox (cairo_t *cr,
 	// a checkbox has no active state, so we use this color for the checked state
 	if (!checkbox->in_cell && draw_bullet && widget->state_type == GTK_STATE_NORMAL)
 		bg = colors->base[GTK_STATE_SELECTED];
-
-	if (widget->state_type == GTK_STATE_INSENSITIVE)
-	{
-		border = colors->shade[5];
-		dot    = &colors->shade[3];
-
-		mrn_gradient_new = murrine_get_decreased_gradient_shades (widget->mrn_gradient, 3.0);
-		mrn_gradient_new.border_shades[0] = murrine_get_decreased_shade (widget->mrn_gradient.border_shades[0], 3.0);
-		mrn_gradient_new.border_shades[1] = murrine_get_decreased_shade (widget->mrn_gradient.border_shades[1], 3.0);
-		highlight_shade_new = murrine_get_decreased_shade (widget->highlight_shade, 2.0);
-		lightborder_shade_new = murrine_get_decreased_shade (widget->lightborder_shade, 2.0);
-	}
-	else
-	{
-		border = colors->text[widget->state_type];
-		dot = &colors->text[widget->state_type];
-	}
 
 	cairo_translate (cr, x, y);
 
@@ -3351,7 +3317,7 @@ murrine_draw_checkbox (cairo_t *cr,
 			cairo_close_path (cr);
 		}
 
-		murrine_set_color_rgba (cr, dot, trans);
+		murrine_set_color_rgba (cr, &dot, trans);
 		cairo_fill (cr);
 	}
 }

--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3081,8 +3081,8 @@ murrine_draw_radiobutton (cairo_t *cr,
                           int x, int y, int width, int height,
                           double trans)
 {
-	MurrineRGB border = colors->text[widget->state_type];
-	MurrineRGB dot = colors->text[widget->state_type];
+	MurrineRGB border = colors->text[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
+	MurrineRGB dot = colors->text[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
 	MurrineRGB bg = colors->base[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
 	gboolean inconsistent = FALSE;
 	gboolean draw_box = !checkbox->in_menu;
@@ -3211,8 +3211,8 @@ murrine_draw_checkbox (cairo_t *cr,
                        int x, int y, int width, int height,
                        double trans)
 {
-	MurrineRGB border = colors->text[widget->state_type];
-	MurrineRGB dot = colors->text[widget->state_type];
+	MurrineRGB border = colors->text[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
+	MurrineRGB dot = colors->text[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
 	MurrineRGB bg = colors->base[checkbox->in_cell ? GTK_STATE_NORMAL : widget->state_type];
 	gboolean inconsistent = FALSE;
 	gboolean draw_box = !checkbox->in_menu;

--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3113,8 +3113,8 @@ murrine_draw_radiobutton (cairo_t *cr,
 	}
 	else
 	{
-		murrine_shade (&bg, 0.6, &border);
-		dot = colors->text[checkbox->in_cell ? GTK_STATE_NORMAL : GTK_STATE_SELECTED];
+		border = colors->text[widget->state_type];
+		dot = colors->text[widget->state_type];
 	}
 
 	cairo_translate (cr, x, y);
@@ -3257,8 +3257,8 @@ murrine_draw_checkbox (cairo_t *cr,
 	}
 	else
 	{
-		murrine_shade (&bg, 0.6, &border);
-		dot = &colors->text[checkbox->in_cell ? GTK_STATE_NORMAL : GTK_STATE_SELECTED];
+		border = colors->text[widget->state_type];
+		dot = &colors->text[widget->state_type];
 	}
 
 	cairo_translate (cr, x, y);


### PR DESCRIPTION
This PR makes CheckBox/OptionBox Gtkrc styling more flexible:
* border-colors are applied in all widget states (still shaded when disabled)
* border-colors match the text colors
* unlimited border roundness
* no additional gradient shades in disabled state
* optimize CellRendererToggle design, which can not be changed using Gtkrc