### PR TITLE
Don't mix default button color with background

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -188,7 +188,7 @@ murrine_draw_button (cairo_t *cr,
 		{
 			mrn_gradient_new.has_border_colors = FALSE;
 			mrn_gradient_new.has_gradient_colors = FALSE;
-			murrine_mix_color (&fill, &button->default_button_color, 0.8, &fill);
+			fill = button->default_button_color;
 		}
 		else
 			murrine_mix_color (&fill, &colors->spot[1], 0.2, &fill);


### PR DESCRIPTION
If a default button color is specified, it should not me mixed with the normal background color, since we want exactly that color in this case.