### PR TITLE
No fixed arrow size in GtkMenuItem

### DIFF
--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2045,18 +2045,7 @@ murrine_style_draw_arrow (GtkStyle     *style,
 	{
 		if (DETAIL ("menuitem"))
 		{
-			if (arrow.direction == MRN_DIRECTION_UP || arrow.direction == MRN_DIRECTION_DOWN)
-			{
-				x = x + width / 2 - 2;
-				y = y + height / 2 - 2;
-				height = 7; width = 8;
-			}
-			else
-			{
-				x = x + width / 2 - 2;
-				y = y + height / 2 - 2;
-				height = 7; width = 8;
-			}
+			// nothing to do
 		}
 		else if (DETAIL ("hscrollbar") || DETAIL ("vscrollbar"))
 		{


### PR DESCRIPTION
Gtk calculates the arrow geometry correctly
for us and takes [GtkMenuItem::arrow-scaling](https://developer.gnome.org/gtk2/stable/GtkArrow.html#GtkArrow--s-arrow-scaling) into
account.