### PR TITLE
Fix tree row unfocused selection background

### DIFF
--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -166,7 +166,7 @@ murrine_set_widget_parameters (const GtkWidget  *widget,
 	params->state_type = (MurrineStateType)state_type;
 	params->corners    = MRN_CORNER_ALL;
 	params->ltr        = murrine_widget_is_ltr ((GtkWidget*)widget);
-	params->focus      = (MURRINE_STYLE (style)->focusstyle != 0) && widget && GTK_WIDGET_HAS_FOCUS (widget);
+	params->focus      = widget && GTK_WIDGET_HAS_FOCUS (widget);
 	params->is_default = widget && GTK_WIDGET_HAS_DEFAULT (widget);
 	
 	GtkBorder *draw_border = NULL;


### PR DESCRIPTION
WidgetParameters.focus indicates the focus state of a widget and should not depend on the focusstyle option. With this patch the selected row background renders correctly with the `base[GTK_STATE_ACTIVE]` if a TreeView is not focused. Should not affect any other widgets.