### PR TITLE
Draw the focus ring on check/radio buttons in a Cocoa style

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3163,6 +3163,11 @@ murrine_draw_radiobutton (cairo_t *cr,
 			             roundness, widget->corners,
 			             mrn_gradient_new, border_alpha);
 
+		if (checkbox->mac_style && checkbox->draw_focus && widget->focus) {
+			cairo_set_line_width (cr, 1.5);
+			murrine_draw_border (cr, &colors->base[GTK_STATE_ACTIVE],
+								 0, 0, width, height, roundness, widget->corners, mrn_gradient_new, 1.0);
+		}
 	}
 
 	if (draw_bullet)
@@ -3333,6 +3338,12 @@ murrine_draw_checkbox (cairo_t *cr,
 		                     1.5, 1.5, width-3, height-3,
 		                     roundness, widget->corners,
 		                     mrn_gradient_new, border_alpha);
+
+		if (checkbox->mac_style && checkbox->draw_focus && widget->focus) {
+			cairo_set_line_width (cr, 1.5);
+			murrine_draw_border (cr, &colors->base[GTK_STATE_ACTIVE], 0, 0,
+								 width, height, roundness, widget->corners, mrn_gradient_new, 1.0);
+		}
 	}
 
 	if (draw_bullet)

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -1740,6 +1740,7 @@ murrine_style_draw_option (DRAW_ARGS)
 	checkbox.in_menu = (widget && widget->parent && GTK_IS_MENU(widget->parent));
 	#ifdef GDK_WINDOWING_QUARTZ
 	checkbox.mac_style = TRUE;
+	checkbox.draw_focus = (murrine_style->focusstyle != 0);
 	#else
 	checkbox.mac_style = FALSE;
 	#endif
@@ -1787,6 +1788,7 @@ murrine_style_draw_check (DRAW_ARGS)
 	checkbox.in_menu = (widget && widget->parent && GTK_IS_MENU(widget->parent));
 	#ifdef GDK_WINDOWING_QUARTZ
 	checkbox.mac_style = TRUE;
+	checkbox.draw_focus = (murrine_style->focusstyle != 0);
 	#else
 	checkbox.mac_style = FALSE;
 	#endif
@@ -2380,8 +2382,13 @@ murrine_style_draw_focus (GtkStyle *style, GdkWindow *window, GtkStateType state
 		/* Focus is always enabled for drop indication in trees */
 		if (g_str_has_prefix (detail, "treeview-drop-indicator"))
 			focus.style = 1;
-		else
+		else 
 			return;
+#ifdef GDK_WINDOWING_QUARTZ
+	} else if (DETAIL ("checkbutton") || DETAIL ("radiobutton")) {
+		/* Checkbutton/radiobutton focus is drawn while drawing the item */
+		return;
+#endif
 	}
 	else
 		focus.style = murrine_style->focusstyle;
@@ -2512,7 +2519,7 @@ murrine_style_draw_focus (GtkStyle *style, GdkWindow *window, GtkStateType state
 		else
 			focus.type = MRN_FOCUS_COLOR_WHEEL_LIGHT;
 	}
-	else if (DETAIL("checkbutton") || DETAIL("radiobutton") || DETAIL("expander"))
+	else if (DETAIL("expander"))
 	{
 		focus.type = MRN_FOCUS_LABEL; /* Let's call it "LABEL" :) */
 		height += 4;

--- a/src/murrine_types.h
+++ b/src/murrine_types.h
@@ -226,6 +226,7 @@ typedef struct
 	boolean           in_cell;
 	boolean           in_menu;
 	boolean           mac_style;
+	boolean           draw_focus;
 } CheckboxParameters;
 
 typedef struct


### PR DESCRIPTION
Makes the focus ring look like Cocoa when drawing on macOS

<img width="187" alt="screen shot 2017-05-09 at 8 00 50 pm" src="https://cloud.githubusercontent.com/assets/1253364/25867768/86ef6280-34f2-11e7-8ba7-e9b31d564e1f.png">
<img width="176" alt="screen shot 2017-05-09 at 8 01 00 pm" src="https://cloud.githubusercontent.com/assets/1253364/25867770/86fbc0c0-34f2-11e7-9be6-b384e6d862c2.png">
<img width="211" alt="screen shot 2017-05-09 at 8 01 35 pm" src="https://cloud.githubusercontent.com/assets/1253364/25867769/86f4a7d6-34f2-11e7-9225-92799c0adbb8.png">