### PR TITLE
[a11y] Fix Default button contrast issues

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3725,14 +3725,6 @@ murrine_draw_focus_border (cairo_t *cr,
 	switch (focus->type)
 	{
 		case MRN_FOCUS_BUTTON_DEFAULT:
-			xoffset = -(focus->padding)-2.0;
-			yoffset = -(focus->padding)-2.0;
-			radius = widget->roundness;
-			focus_fill = FALSE;
-			focus_shadow = TRUE;
-			border_alpha = 0.2;
-			shadow_alpha = 0.4;
-			break;
 		case MRN_FOCUS_BUTTON:
 			xoffset = -(focus->padding)-2.0;
 			yoffset = -(focus->padding)-2.0;

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2296,9 +2296,13 @@ murrine_style_draw_layout (GtkStyle     *style,
 	else
 	{
 		GtkWidget *button = gtk_widget_get_ancestor (widget, GTK_TYPE_BUTTON);
-		if (DETAIL ("label") && button)
-			gdk_draw_layout_with_colors(window, gc, x, y, layout, &button->style->fg[state_type], NULL);
-		else
+		if (DETAIL ("label") && button) {
+			MurrineRGB *color = &button->style->fg[state_type];
+			// text style is not used by buttons, so we can use it here to define a different label color for default buttons
+			if (GTK_WIDGET_HAS_DEFAULT (button))
+				color = &button->style->text[state_type];
+			gdk_draw_layout_with_colors(window, gc, x, y, layout, color, NULL);
+		} else
 			gdk_draw_layout (window, gc, x, y, layout);
 	}
 


### PR DESCRIPTION
This PR improves default button rendering:

* ec3aa52: removes the special focus parameters for default buttons, this looked a bit nicer for specific (grey-ish) colors, but made it worse for light colors, like the blue on macOS
* 791e5b4: allows to adjust the default button label color using the `text` style (which is unused otherwise, since buttons use only `fg` colors)

TODO: I'll attach some screenshots asap