### PR TITLE
Accessibility improvements

### DIFF
--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3725,14 +3725,6 @@ murrine_draw_focus_border (cairo_t *cr,
 	switch (focus->type)
 	{
 		case MRN_FOCUS_BUTTON_DEFAULT:
-			xoffset = -(focus->padding)-2.0;
-			yoffset = -(focus->padding)-2.0;
-			radius = widget->roundness;
-			focus_fill = FALSE;
-			focus_shadow = TRUE;
-			border_alpha = 0.2;
-			shadow_alpha = 0.4;
-			break;
 		case MRN_FOCUS_BUTTON:
 			xoffset = -(focus->padding)-2.0;
 			yoffset = -(focus->padding)-2.0;

--- a/src/murrine_draw.c
+++ b/src/murrine_draw.c
@@ -3740,8 +3740,8 @@ murrine_draw_focus_border (cairo_t *cr,
 			radius = widget->roundness;
 			break;
 		case MRN_FOCUS_LABEL:
-			xoffset = 0.0;
-			yoffset = 0.0;
+			xoffset = -(focus->padding);
+			yoffset = -(focus->padding);
 			radius = widget->roundness;
 			break;
 		case MRN_FOCUS_TREEVIEW:
@@ -3847,8 +3847,8 @@ murrine_draw_focus_inner (cairo_t *cr,
 			radius = widget->roundness-1;
 			break;
 		case MRN_FOCUS_LABEL:
-			xoffset = 0.0;
-			yoffset = 0.0;
+			xoffset = -(focus->padding);
+			yoffset = -(focus->padding);
 			radius = widget->roundness;
 			break;
 		case MRN_FOCUS_TREEVIEW:

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2530,6 +2530,10 @@ murrine_style_draw_focus (GtkStyle *style, GdkWindow *window, GtkStateType state
 	{
 		focus.type = MRN_FOCUS_ICONVIEW;
 	}
+	else if (DETAIL("label"))
+	{
+		focus.type = MRN_FOCUS_LABEL;
+	}
 	else
 	{
 		focus.type = MRN_FOCUS_UNKNOWN; /* Custom widgets (Beagle) and something unknown */

--- a/src/murrine_style.c
+++ b/src/murrine_style.c
@@ -2296,9 +2296,13 @@ murrine_style_draw_layout (GtkStyle     *style,
 	else
 	{
 		GtkWidget *button = gtk_widget_get_ancestor (widget, GTK_TYPE_BUTTON);
-		if (DETAIL ("label") && button)
-			gdk_draw_layout_with_colors(window, gc, x, y, layout, &button->style->fg[state_type], NULL);
-		else
+		if (DETAIL ("label") && button) {
+			MurrineRGB *color = &button->style->fg[state_type];
+			// text style is not used by buttons, so we can use it here to define a different label color for default buttons
+			if (GTK_WIDGET_HAS_DEFAULT (button))
+				color = &button->style->text[state_type];
+			gdk_draw_layout_with_colors(window, gc, x, y, layout, color, NULL);
+		} else
 			gdk_draw_layout (window, gc, x, y, layout);
 	}
 


### PR DESCRIPTION
This PR improves default button and label focus rendering:

* ec3aa52: removes the special focus parameters for default buttons, this looked a bit nicer for specific (grey-ish) colors, but made it worse for light colors, like the blue on macOS
* 791e5b4: allows to adjust the default button label color using the `text` style (which is unused otherwise, since buttons use only `fg` colors)
* 19eadb7: allows to specify custom focus parameters for labels
* 9154b68: Adds support for label focus padding

See https://github.com/mono/monodevelop/pull/9286 for updated screenshots and gtkrcs making use of the changes